### PR TITLE
Fix vrelease: use verkada org and vlinux/vmacos workflow names

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,15 +28,15 @@ cat-python-json archive:
 # Download release artifacts from GitHub Actions
 release-download-distributions token commit:
   mkdir -p dist
-  cargo run --release -- fetch-release-distributions --token {{token}} --commit {{commit}} --dest dist
+  cargo run --release -- fetch-release-distributions --org verkada --token {{token}} --commit {{commit}} --dest dist
 
 # Upload release artifacts to a GitHub release.
 release-upload-distributions token datetime tag:
-  cargo run --release -- upload-release-distributions --token {{token}} --datetime {{datetime}} --tag {{tag}} --dist dist
+  cargo run --release -- upload-release-distributions --org verkada --token {{token}} --datetime {{datetime}} --tag {{tag}} --dist dist
 
 # "Upload" release artifacts to a GitHub release in dry-run mode (skip upload).
 release-upload-distributions-dry-run token datetime tag:
-  cargo run --release -- upload-release-distributions --token {{token}} --datetime {{datetime}} --tag {{tag}} --dist dist -n
+  cargo run --release -- upload-release-distributions --org verkada --token {{token}} --datetime {{datetime}} --tag {{tag}} --dist dist -n
 
 # Promote a tag to "latest" by pushing to the `latest-release` branch.
 release-set-latest-release tag:
@@ -51,8 +51,8 @@ release-set-latest-release tag:
   {
     "version": 1,
     "tag": "{{tag}}",
-    "release_url": "https://github.com/astral-sh/python-build-standalone/releases/tag/{{tag}}",
-    "asset_url_prefix": "https://github.com/astral-sh/python-build-standalone/releases/download/{{tag}}"
+    "release_url": "https://github.com/verkada/python-build-standalone/releases/tag/{{tag}}",
+    "asset_url_prefix": "https://github.com/verkada/python-build-standalone/releases/download/{{tag}}"
   }
   EOF
 


### PR DESCRIPTION
## Summary
- Add `--org verkada` to release commands in Justfile so artifacts are fetched from the correct repo
- Update `latest-release.json` URLs to point to verkada fork

Note: Also requires PR #18 for workflow name fixes (`vmacos.yml`, `vlinux.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)